### PR TITLE
Adding support for the HTML Input of type "number".

### DIFF
--- a/src/angular-initial-value.js
+++ b/src/angular-initial-value.js
@@ -10,8 +10,8 @@ var initialValueModule = angular.module('initialValue', [])
 
 		return result;
 	};
-  
-  
+
+
   return{
     restrict: 'A',
     controller: ['$scope', '$element', '$attrs', '$parse', function($scope, $element, $attrs, $parse){
@@ -25,7 +25,9 @@ var initialValueModule = angular.module('initialValue', [])
           val = $element[0].checked ? true : undefined;
         } else if($element.attr('type') === 'radio'){
           val = ($element[0].checked || $element.attr('selected') !== undefined) ? $element.val() : undefined;
-        } 
+        } else if($element.attr('type') === 'number'){
+          val = ($element.val() != undefined) ? parseFloat($element.val()) : undefined;
+        }
       }
 
       if($attrs.ngModel){

--- a/test/example.html
+++ b/test/example.html
@@ -30,7 +30,7 @@
 
   <div>
     Phone (type="tel")
-    <input type="tel" value="12 3456789" name="tel" initial-value ng-model="tel" id="tel" /> 
+    <input type="tel" value="12 3456789" name="tel" initial-value ng-model="tel" id="tel" />
     {{tel}}
   </div>
 
@@ -90,13 +90,13 @@
 
   <div>
     <label>
-      <input type="radio" initial-value checked name="sex" ng-model="male" value="male" id="radio_male" />  
+      <input type="radio" initial-value checked name="sex" ng-model="male" value="male" id="radio_male" />
       Male
     </label>
     {{male}}
     <br>
     <label>
-      <input type="radio" name="sex" ng-model="female" value="female" id="radio_female"/>  
+      <input type="radio" name="sex" ng-model="female" value="female" id="radio_female"/>
       Female
     </label>
     {{female}}
@@ -105,6 +105,11 @@
   <div>
     <textarea initial-value ng-model="textarea" id="textarea" cols="30" rows="10">Lorem ipsum</textarea>
     {{textarea}}
+  </div>
+
+  <div>
+    <input initial-value ng-model="number" id="number" value="34" step="1" type="number"/>
+    {{number}}
   </div>
 </body>
 </html>

--- a/test/general-spec.js
+++ b/test/general-spec.js
@@ -9,7 +9,8 @@ describe("e2e", function() {
     range:    '10',
     search:   'my name is',
     url:      'http://google.com',
-    password: 'password123'
+    password: 'password123',
+    number: '34'
   }
 
   function assertValue(key){


### PR DESCRIPTION
Needed this because $element.val() would return a typeof "string" instead of typeof "number".
